### PR TITLE
Support for fb:explicitly_shared

### DIFF
--- a/opengraph.js
+++ b/opengraph.js
@@ -63,14 +63,21 @@ OpenGraph.prototype.show = function(user_id,access_token,action,callback){
 }
 
 // **Publish**
-OpenGraph.prototype.publish = function(user_id,access_token,action,objectName,object,callback){
+OpenGraph.prototype.publish = function(user_id,access_token,action,objectName,object,explicitlyShared,callback){
   var uri = getOpenGraphUrl(user_id,this.namespace,access_token,action),
-      form = {}
+      form = {},
+      callbackFn = callback || explicitlyShared // curried
+
+  if (callback && explicitlyShared === true) {
+    // https://developers.facebook.com/docs/technical-guides/opengraph/explicit-sharing/
+    form['fb:explicitly_shared'] = true
+  }
+
   form[objectName] = object
   request.post({
     uri : uri,
     form : form
-  },parseResponse.bind(this,callback))
+  },parseResponse.bind(this,callbackFn))
 }
 
 // **Delete**


### PR DESCRIPTION
I've added support for this attribute as a curried argument to the publish() method, to make the signature look like this:

OpenGraph.prototype.publish = function(user_id,access_token,action,objectName,object,explicitlyShared,callback)

As explicitlyShared is optional, this change is non-breaking and existing use of this function will continue to work as intended.

See: https://developers.facebook.com/docs/technical-guides/opengraph/explicit-sharing/
